### PR TITLE
Tsf 3650 diagnosekoder fra npm

### DIFF
--- a/packages/medisinsk-vilkår/Dockerfile
+++ b/packages/medisinsk-vilkår/Dockerfile
@@ -2,6 +2,12 @@ FROM nginxinc/nginx-unprivileged:1.23.1-alpine
 
 ADD server.nginx /etc/nginx/conf.d/app.conf.template
 COPY build /usr/share/nginx/html
+# Create gzipped versions of the static assets
+USER root
+RUN gzip -k /usr/share/nginx/html/1/*
+# Back to nginx user
+USER 101
+
 ADD start-server.sh ./start-server.sh
 
 EXPOSE 8080

--- a/packages/medisinsk-vilkår/mock/handlers.ts
+++ b/packages/medisinsk-vilkår/mock/handlers.ts
@@ -191,10 +191,6 @@ export const handlers = [
         return res(ctx.status(200), ctx.json(mockedDokumentliste));
     }),
 
-    rest.get('http://localhost:8081/k9/diagnosekoder', (req, res, ctx) => {
-        return res(ctx.status(200), ctx.json(mockedDiagnosekodeSearchResponse));
-    }),
-
     rest.get('http://localhost:8082/mock/diagnosekoder', (req, res, ctx) => {
         return res(ctx.status(200), ctx.json(mockedDiagnosekoderesponse));
     }),

--- a/packages/medisinsk-vilkår/mock/mocked-data/mockedDiagnosekodeResponse.ts
+++ b/packages/medisinsk-vilkår/mock/mocked-data/mockedDiagnosekodeResponse.ts
@@ -1,7 +1,7 @@
 import LinkRel from '../../src/constants/LinkRel';
 
 export default {
-    diagnosekoder: ['hei', 'test'],
+    diagnosekoder: ['A001', 'B04'],
     links: [
         {
             rel: LinkRel.ENDRE_DIAGNOSEKODER,

--- a/packages/medisinsk-vilkår/package.json
+++ b/packages/medisinsk-vilkår/package.json
@@ -33,6 +33,7 @@
         "cross-env": "7.0.3"
     },
     "dependencies": {
+        "@navikt/diagnosekoder": "^1.2023.0",
         "@navikt/ds-css": "4.12.3",
         "@navikt/ds-icons": "3.4.3",
         "@navikt/ds-react": "4.12.1",

--- a/packages/medisinsk-vilkår/server.nginx
+++ b/packages/medisinsk-vilkår/server.nginx
@@ -4,6 +4,8 @@ server {
 	location / {
             root   /usr/share/nginx/html;
             index  index.html index.htm;
+
+            gzip_static on;
         }
 
   # Health check for NAIS

--- a/packages/medisinsk-vilkår/src/ui/components/diagnosekode-modal/DiagnosekodeModal.tsx
+++ b/packages/medisinsk-vilkår/src/ui/components/diagnosekode-modal/DiagnosekodeModal.tsx
@@ -4,14 +4,16 @@ import React from 'react';
 import DiagnosekodeSelector from '../../form/pure/PureDiagnosekodeSelector';
 import styles from '../diagnosekodeoversikt/diagnosekodeoversikt.css';
 import ModalFormWrapper from '../modal-form-wrapper/ModalFormWrapper';
+import type {DiagnosekodeSearcherPromise} from "../../../util/diagnosekodeSearcher";
 
 interface DiagnosekodeModalProps {
     isOpen: boolean;
     onRequestClose: () => void;
     onSaveClick: (diagnosekoder: string[]) => Promise<unknown>;
+    searcherPromise: DiagnosekodeSearcherPromise;
 }
 
-const DiagnosekodeModal = ({ isOpen, onRequestClose, onSaveClick }: DiagnosekodeModalProps): JSX.Element => {
+const DiagnosekodeModal = ({ isOpen, onRequestClose, onSaveClick, searcherPromise }: DiagnosekodeModalProps): JSX.Element => {
     const [selectedDiagnosekoder, setSelectedDiagnosekoder] = React.useState([]);
     const [isSubmitting, setIsSubmitting] = React.useState(false);
 
@@ -46,6 +48,7 @@ const DiagnosekodeModal = ({ isOpen, onRequestClose, onSaveClick }: Diagnosekode
                                 label="Diagnosekode"
                                 selectedDiagnosekoder={selectedDiagnosekoder}
                                 hideLabel
+                                searcherPromise={searcherPromise}
                             />
                         </Box>
                         <Box marginTop={Margin.xLarge}>

--- a/packages/medisinsk-vilkår/src/ui/components/diagnosekode-modal/DiagnosekodeModal.tsx
+++ b/packages/medisinsk-vilkår/src/ui/components/diagnosekode-modal/DiagnosekodeModal.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import DiagnosekodeSelector from '../../form/pure/PureDiagnosekodeSelector';
 import styles from '../diagnosekodeoversikt/diagnosekodeoversikt.css';
 import ModalFormWrapper from '../modal-form-wrapper/ModalFormWrapper';
-import type {DiagnosekodeSearcherPromise} from "../../../util/diagnosekodeSearcher";
+import type { DiagnosekodeSearcherPromise } from '../../../util/diagnosekodeSearcher';
 
 interface DiagnosekodeModalProps {
     isOpen: boolean;
@@ -13,7 +13,12 @@ interface DiagnosekodeModalProps {
     searcherPromise: DiagnosekodeSearcherPromise;
 }
 
-const DiagnosekodeModal = ({ isOpen, onRequestClose, onSaveClick, searcherPromise }: DiagnosekodeModalProps): JSX.Element => {
+const DiagnosekodeModal = ({
+    isOpen,
+    onRequestClose,
+    onSaveClick,
+    searcherPromise,
+}: DiagnosekodeModalProps): JSX.Element => {
     const [selectedDiagnosekoder, setSelectedDiagnosekoder] = React.useState([]);
     const [isSubmitting, setIsSubmitting] = React.useState(false);
 

--- a/packages/medisinsk-vilkår/src/ui/components/diagnosekodeoversikt/Diagnosekodeoversikt.tsx
+++ b/packages/medisinsk-vilkår/src/ui/components/diagnosekodeoversikt/Diagnosekodeoversikt.tsx
@@ -14,21 +14,21 @@ import DiagnosekodeModal from '../diagnosekode-modal/DiagnosekodeModal';
 import Diagnosekodeliste from '../diagnosekodeliste/Diagnosekodeliste';
 import IconWithText from '../icon-with-text/IconWithText';
 import WriteAccessBoundContent from '../write-access-bound-content/WriteAccessBoundContent';
-import initDiagnosekodeSearcher, {toLegacyDiagnosekode} from "../../../util/diagnosekodeSearcher";
+import initDiagnosekodeSearcher, { toLegacyDiagnosekode } from '../../../util/diagnosekodeSearcher';
 
 // Start initializing diagnosekode searcher instance, with pagesize 8, so that it can be used both here and in the DiagnosekodeModal.
 // This reuse is possible since we don't use the paging functionality in the instance anyways.
-const diagnosekodeSearcherPromise = initDiagnosekodeSearcher(8)
+const diagnosekodeSearcherPromise = initDiagnosekodeSearcher(8);
 
 const fetchDiagnosekoderByQuery = async (queryString: string): Promise<Diagnosekode> => {
-    const searcher = await diagnosekodeSearcherPromise
-    const searchResult = searcher.search(queryString, 1)
+    const searcher = await diagnosekodeSearcherPromise;
+    const searchResult = searcher.search(queryString, 1);
     // This function only returns the found diagnosecode if there is exactly one diagnosecode found.
-    if(searchResult.diagnosekoder.length === 1 && !searchResult.hasMore) {
-        return toLegacyDiagnosekode(searchResult.diagnosekoder[0])
+    if (searchResult.diagnosekoder.length === 1 && !searchResult.hasMore) {
+        return toLegacyDiagnosekode(searchResult.diagnosekoder[0]);
     }
-    return {kode: queryString, beskrivelse: ''}
-}
+    return { kode: queryString, beskrivelse: '' };
+};
 
 interface DiagnosekodeoversiktProps {
     onDiagnosekoderUpdated: () => void;

--- a/packages/medisinsk-vilkår/src/ui/components/diagnosekodeoversikt/Diagnosekodeoversikt.tsx
+++ b/packages/medisinsk-vilkår/src/ui/components/diagnosekodeoversikt/Diagnosekodeoversikt.tsx
@@ -16,7 +16,9 @@ import IconWithText from '../icon-with-text/IconWithText';
 import WriteAccessBoundContent from '../write-access-bound-content/WriteAccessBoundContent';
 import initDiagnosekodeSearcher, {toLegacyDiagnosekode} from "../../../util/diagnosekodeSearcher";
 
-const diagnosekodeSearcherPromise = initDiagnosekodeSearcher(1)
+// Start initializing diagnosekode searcher instance, with pagesize 8, so that it can be used both here and in the DiagnosekodeModal.
+// This reuse is possible since we don't use the paging functionality in the instance anyways.
+const diagnosekodeSearcherPromise = initDiagnosekodeSearcher(8)
 
 const fetchDiagnosekoderByQuery = async (queryString: string): Promise<Diagnosekode> => {
     const searcher = await diagnosekodeSearcherPromise
@@ -148,6 +150,7 @@ const Diagnosekodeoversikt = ({ onDiagnosekoderUpdated }: DiagnosekodeoversiktPr
                 isOpen={modalIsOpen}
                 onSaveClick={lagreDiagnosekodeMutation.mutateAsync}
                 onRequestClose={() => setModalIsOpen(false)}
+                searcherPromise={diagnosekodeSearcherPromise}
             />
         </div>
     );

--- a/packages/medisinsk-vilkår/src/ui/form/pure/PureDiagnosekodeSelector.tsx
+++ b/packages/medisinsk-vilkår/src/ui/form/pure/PureDiagnosekodeSelector.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import Diagnosekode from '../../../types/Diagnosekode';
 import DeleteButton from '../../components/delete-button/DeleteButton';
 import styles from './diagnosekodeSelector.css';
+import initDiagnosekodeSearcher, {toLegacyDiagnosekode} from "../../../util/diagnosekodeSearcher";
 
 interface Suggestion {
     key: string;
@@ -20,8 +21,15 @@ interface DiagnosekodeSelectorProps {
     selectedDiagnosekoder: string[];
 }
 
-const fetchDiagnosekoderByQuery = (queryString: string) =>
-    fetch(`/k9/diagnosekoder/?query=${queryString}&max=8`).then((response) => response.json());
+// Start loading the searcher immediately
+// TODO De-duplicate this init with the one in Diagnosekodeoversikt.tsx, we can use the same instance for both of these searches (there is no paging)
+const diagnosekodeSearcherPromise = initDiagnosekodeSearcher(8)
+
+const fetchDiagnosekoderByQuery = async (queryString: string): Promise<Diagnosekode[]> => {
+    const searcher = await diagnosekodeSearcherPromise;
+    const searchResult = searcher.search(queryString, 1);
+    return searchResult.diagnosekoder.map(toLegacyDiagnosekode)
+}
 
 const PureDiagnosekodeSelector = ({
     label,

--- a/packages/medisinsk-vilkår/src/ui/form/pure/PureDiagnosekodeSelector.tsx
+++ b/packages/medisinsk-vilkår/src/ui/form/pure/PureDiagnosekodeSelector.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import Diagnosekode from '../../../types/Diagnosekode';
 import DeleteButton from '../../components/delete-button/DeleteButton';
 import styles from './diagnosekodeSelector.css';
-import {type DiagnosekodeSearcherPromise, toLegacyDiagnosekode} from "../../../util/diagnosekodeSearcher";
+import { type DiagnosekodeSearcherPromise, toLegacyDiagnosekode } from '../../../util/diagnosekodeSearcher';
 
 interface Suggestion {
     key: string;
@@ -41,7 +41,9 @@ const PureDiagnosekodeSelector = ({
         if (queryString.length >= 3) {
             setIsLoading(true);
             const searcher = await searcherPromise;
-            const diagnosekoder: Diagnosekode[] = (await searcher.search(queryString, 1)).diagnosekoder.map(toLegacyDiagnosekode);
+            const diagnosekoder: Diagnosekode[] = (await searcher.search(queryString, 1)).diagnosekoder.map(
+                toLegacyDiagnosekode
+            );
             setIsLoading(false);
             return diagnosekoder.map(({ kode, beskrivelse }) => ({
                 key: kode,

--- a/packages/medisinsk-vilkår/src/util/diagnosekodeSearcher.ts
+++ b/packages/medisinsk-vilkår/src/util/diagnosekodeSearcher.ts
@@ -5,15 +5,19 @@
 // This import is a 1.3MB package, so we import it asynchronously as a separate bundle.
 // Should then not impact loading time too much since it will be cached and only reloaded on first load, or once a year.
 
-import type {DiagnosekodeSearcher, ICD10Diagnosekode} from "@navikt/diagnosekoder";
-import Diagnosekode from "../types/Diagnosekode";
+import type { DiagnosekodeSearcher, ICD10Diagnosekode } from '@navikt/diagnosekoder';
+import Diagnosekode from '../types/Diagnosekode';
 
-export type DiagnosekodeSearcherPromise = Promise<DiagnosekodeSearcher<ICD10Diagnosekode>>
+export type DiagnosekodeSearcherPromise = Promise<DiagnosekodeSearcher<ICD10Diagnosekode>>;
 
-const initDiagnosekodeSearcher = async (pageSize: number): DiagnosekodeSearcherPromise => import('@navikt/diagnosekoder')
-    .then(diagnosekodeModule => new diagnosekodeModule.DiagnosekodeSearcher(diagnosekodeModule.ICD10, pageSize));
+const initDiagnosekodeSearcher = async (pageSize: number): DiagnosekodeSearcherPromise =>
+    import('@navikt/diagnosekoder').then(
+        (diagnosekodeModule) => new diagnosekodeModule.DiagnosekodeSearcher(diagnosekodeModule.ICD10, pageSize)
+    );
 
-export const toLegacyDiagnosekode = (icd10Code: ICD10Diagnosekode): Diagnosekode =>
-    ({kode: icd10Code.code, beskrivelse: icd10Code.text})
+export const toLegacyDiagnosekode = (icd10Code: ICD10Diagnosekode): Diagnosekode => ({
+    kode: icd10Code.code,
+    beskrivelse: icd10Code.text,
+});
 
 export default initDiagnosekodeSearcher;

--- a/packages/medisinsk-vilkår/src/util/diagnosekodeSearcher.ts
+++ b/packages/medisinsk-vilkår/src/util/diagnosekodeSearcher.ts
@@ -1,0 +1,17 @@
+// This module is here to load and initialize a DiagnosekodeSearcher instance the replaces the external diagnosekode-api service.
+// Instead of querying the external service we load all diagnose codes into a searcher class instance from the @navikt/diagnosekoder
+// package, and do the lookup of diagnose codes agains this instance directly.
+//
+// This import is a 1.3MB package, so we import it asynchronously as a separate bundle.
+// Should then not impact loading time too much since it will be cached and only reloaded on first load, or once a year.
+
+import { type ICD10Diagnosekode} from "@navikt/diagnosekoder/lib/ICD10Diagnosekode";
+import Diagnosekode from "../types/Diagnosekode";
+
+const initDiagnosekodeSearcher = async (pageSize: number) => import('@navikt/diagnosekoder')
+    .then(diagnosekodeModule => new diagnosekodeModule.DiagnosekodeSearcher(diagnosekodeModule.ICD10, pageSize));
+
+export const toLegacyDiagnosekode = (icd10Code: ICD10Diagnosekode): Diagnosekode =>
+    ({kode: icd10Code.code, beskrivelse: icd10Code.text})
+
+export default initDiagnosekodeSearcher;

--- a/packages/medisinsk-vilkår/src/util/diagnosekodeSearcher.ts
+++ b/packages/medisinsk-vilkår/src/util/diagnosekodeSearcher.ts
@@ -5,10 +5,12 @@
 // This import is a 1.3MB package, so we import it asynchronously as a separate bundle.
 // Should then not impact loading time too much since it will be cached and only reloaded on first load, or once a year.
 
-import { type ICD10Diagnosekode} from "@navikt/diagnosekoder/lib/ICD10Diagnosekode";
+import type {DiagnosekodeSearcher, ICD10Diagnosekode} from "@navikt/diagnosekoder";
 import Diagnosekode from "../types/Diagnosekode";
 
-const initDiagnosekodeSearcher = async (pageSize: number) => import('@navikt/diagnosekoder')
+export type DiagnosekodeSearcherPromise = Promise<DiagnosekodeSearcher<ICD10Diagnosekode>>
+
+const initDiagnosekodeSearcher = async (pageSize: number): DiagnosekodeSearcherPromise => import('@navikt/diagnosekoder')
     .then(diagnosekodeModule => new diagnosekodeModule.DiagnosekodeSearcher(diagnosekodeModule.ICD10, pageSize));
 
 export const toLegacyDiagnosekode = (icd10Code: ICD10Diagnosekode): Diagnosekode =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4016,6 +4016,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@navikt/diagnosekoder@npm:^1.2023.0":
+  version: 1.2023.0
+  resolution: "@navikt/diagnosekoder@npm:1.2023.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fdiagnosekoder%2F1.2023.0%2F5a183052f0676e45a88cb9ebb8696d85452f54e6"
+  checksum: 8f98bc41c36801383532e258873e5b1f35eb6e1e45cf332db3178577c97aa77c7bffc18de8ea2c27f4a6b7bc2345a21a9a81b11d207ce543e3d26dce925e9649
+  languageName: node
+  linkType: hard
+
 "@navikt/ds-css@npm:4.12.3":
   version: 4.12.3
   resolution: "@navikt/ds-css@npm:4.12.3::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fds-css%2F4.12.3%2F49e36eb3a1060bb5d4d73975accbdb4ec5a79f8b"
@@ -17804,6 +17811,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "medisinsk-vilkar-frontend@workspace:packages/medisinsk-vilkår"
   dependencies:
+    "@navikt/diagnosekoder": ^1.2023.0
     "@navikt/ds-css": 4.12.3
     "@navikt/ds-icons": 3.4.3
     "@navikt/ds-react": 4.12.1


### PR DESCRIPTION
Erstatter bruken av /k9/diagnosekoder service med importert npm pakke som inneheld diagnosekodane.

Når denne er rulla ut kan vi sannsynlegvis fjerne heile diagnosekode-api applikasjonen.